### PR TITLE
Create a Hugo website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+
+      - name: Build site with Hugo
+        run: hugo --minify
+
+      - name: Check HTML
+        uses: chabad360/htmlproofer@master
+        with:
+          directory: "./public"
+          arguments: --only-4xx --check-favicon --check-html --assume-extension --empty-alt-ignore --disable-external
+        continue-on-error: true
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Hugo
+public/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/ananke"]
+	path = themes/ananke
+	url = https://github.com/theNewDynamic/gohugo-theme-ananke.git

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ A landing page for how to structure and run Research Dugnads!
 **Table of Contents:**
 
 - [Working with the Website Locally](#working-with-the-website-locally)
+  - [Installing Hugo](#installing-hugo)
+  - [Creating new content](#creating-new-content)
+  - [Locally rendering changes](#locally-rendering-changes)
+  - [Changing the theme](#changing-the-theme)
+  - [Updating the theme](#updating-the-theme)
 
 ---
 
@@ -12,7 +17,7 @@ A landing page for how to structure and run Research Dugnads!
 
 The website is built using a tool called [Hugo](https://gohugo.io/)
 
-### Installing Hugo with Homebrew
+### Installing Hugo
 
 On MacOS using Homebrew, install Hugo using the following command.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# dugnads-hq
+# Research Dugnads HQ
+
 A landing page for how to structure and run Research Dugnads!
+
+**Table of Contents:**
+
+- [Working with the Website Locally](#working-with-the-website-locally)
+
+---
+
+## Working with the Website Locally
+
+The website is built using a tool called [Hugo](https://gohugo.io/)
+
+### Installing Hugo with Homebrew
+
+On MacOS using Homebrew, install Hugo using the following command.
+
+```bash
+brew install hugo
+```
+
+See Hugo's [Installation Guide](https://gohugo.io/getting-started/installing/) for other systems.
+
+### Creating new content
+
+The below command will create a new content file with the appropriate headings.
+
+:warning: Make sure this command is run from the root of the directory.
+
+```bash
+hugo new path/to/new-content.md
+```
+
+### Locally rendering changes
+
+To see your changes locally, run the below command and then open `localhost:1313` in your browser.
+
+```bash
+hugo server -D
+```
+
+### Changing the theme
+
+Select a new theme from https://themes.gohugo.io/ and run the following command, updating `USERNAME` and `REPONAME` as appropriate.
+
+```bash
+git submodule add https://github.com/USERNAME/REPONAME.git theme/REPONAME
+```
+
+### Updating the theme
+
+To pull in any upstream changes to the theme being used as a git submodule, run the following.
+
+```bash
+git submodule update --remote
+```

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,6 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---
+

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+baseURL = "http://example.org/"
+languageCode = "en-us"
+title = "My New Hugo Site"
+theme = "ananke"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://example.org/"
-languageCode = "en-us"
-title = "My New Hugo Site"
+baseURL = "http://research-dugnads.github.io/"
+languageCode = "en-gb"
+title = "Research Dugnads"
 theme = "ananke"


### PR DESCRIPTION
This PR adds a website built with hugo (no content), relevant gitignore file, a CI workflow to deploy the site to gh-pages, and some documentation in the README

fix #1 